### PR TITLE
build: use github packages for unity upm

### DIFF
--- a/msbuild/Base128/Base128.dll.meta
+++ b/msbuild/Base128/Base128.dll.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7fe1717f6ef204069af1d31b4b7aa7e0

--- a/msbuild/Base128/justfile
+++ b/msbuild/Base128/justfile
@@ -28,5 +28,6 @@ assemble_upm: clone build && clean
     mkdir -p {{upm_contents_dir}}
     cp {{dotnet_artifact_dir / dll_name}} {{upm_contents_dir}}
     cp package.json {{upm_contents_dir}}
+    cp *.meta {{upm_contents_dir}}
     mkdir -p {{out_dir}}
     npm pack --pack-destination {{out_dir}} {{upm_contents_dir}}

--- a/msbuild/Base128/package.json
+++ b/msbuild/Base128/package.json
@@ -3,5 +3,7 @@
   "version": "1.2.2",
   "displayName": "Base128",
   "description": "binary serializing and deserializing integer types as variable length integers.",
-  "documentationUrl": "https://github.com/Wojmik/Base128"
+  "documentationUrl": "https://github.com/Wojmik/Base128",
+  "publishConfig": { "registry": "https://npm.pkg.github.com/@BasisVR" },
+  "repository":"https://github.com/BasisVR/UpmBuilds"
 }

--- a/msbuild/Base128/package.json.meta
+++ b/msbuild/Base128/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e6c1fa5762b704c7b869c85df6f73f3b
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
@dooly123 decided that the requirement for developers to both create a github account and configure their `~/.upmconfig` is too inconvenient/extreme, so this approach is a nonstarter.

I'm gonna merge it for now but we will switch over to publishing the tgz files to github releases instead, and then have a simple cli tool to download those tgz files, and an editor plugin to handle updating the project's manifest.json.